### PR TITLE
fix: search dedup, document_id resolution, fallback disclosure

### DIFF
--- a/src/tools/build-legal-stance.ts
+++ b/src/tools/build-legal-stance.ts
@@ -3,7 +3,8 @@
  */
 
 import type { Database } from '@ansvar/mcp-sqlite';
-import { buildFtsQueryVariantsLegacy as buildFtsQueryVariants } from '../utils/fts-query.js';
+import { buildFtsQueryVariants, buildLikePattern, sanitizeFtsInput } from '../utils/fts-query.js';
+import { resolveDocumentId } from '../utils/statute-id.js';
 import { generateResponseMetadata, type ToolResponse } from '../utils/metadata.js';
 
 export interface BuildLegalStanceInput {
@@ -35,58 +36,153 @@ const MAX_LIMIT = 20;
 
 export async function buildLegalStance(
   db: Database,
-  input: BuildLegalStanceInput
+  input: BuildLegalStanceInput,
 ): Promise<ToolResponse<LegalStanceResult>> {
   if (!input.query || input.query.trim().length === 0) {
     return {
       results: { query: '', provisions: [], total_citations: 0 },
-      _metadata: generateResponseMetadata(db)
+      _metadata: generateResponseMetadata(db),
     };
   }
 
   const limit = Math.min(Math.max(input.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
-  const queryVariants = buildFtsQueryVariants(input.query);
+  // Fetch extra rows to account for deduplication
+  const fetchLimit = limit * 2;
+  const queryVariants = buildFtsQueryVariants(sanitizeFtsInput(input.query));
 
-  let provSql = `
-    SELECT
-      lp.document_id,
-      ld.title as document_title,
-      lp.provision_ref,
-      lp.title,
-      snippet(provisions_fts, 0, '>>>', '<<<', '...', 32) as snippet,
-      bm25(provisions_fts) as relevance
-    FROM provisions_fts
-    JOIN legal_provisions lp ON lp.id = provisions_fts.rowid
-    JOIN legal_documents ld ON ld.id = lp.document_id
-    WHERE provisions_fts MATCH ?
-  `;
-
-  const provParams: (string | number)[] = [];
-
+  // Resolve document_id from title if provided (same resolution as get_provision)
+  let resolvedDocId: string | undefined;
   if (input.document_id) {
-    provSql += ` AND lp.document_id = ?`;
-    provParams.push(input.document_id);
+    const resolved = resolveDocumentId(db, input.document_id);
+    resolvedDocId = resolved ?? undefined;
+    if (!resolved) {
+      return {
+        results: { query: input.query, provisions: [], total_citations: 0 },
+        _metadata: {
+          ...generateResponseMetadata(db),
+          note: `No document found matching "${input.document_id}"`,
+        },
+      };
+    }
   }
 
-  provSql += ` ORDER BY relevance LIMIT ?`;
-  provParams.push(limit);
+  let queryStrategy = 'none';
+  for (const ftsQuery of queryVariants) {
+    let provSql = `
+      SELECT
+        lp.document_id,
+        ld.title as document_title,
+        lp.provision_ref,
+        lp.title,
+        snippet(provisions_fts, 0, '>>>', '<<<', '...', 32) as snippet,
+        bm25(provisions_fts) as relevance
+      FROM provisions_fts
+      JOIN legal_provisions lp ON lp.id = provisions_fts.rowid
+      JOIN legal_documents ld ON ld.id = lp.document_id
+      WHERE provisions_fts MATCH ?
+    `;
+    const provParams: (string | number)[] = [ftsQuery];
 
-  const runProvisionQuery = (ftsQuery: string): ProvisionHit[] => {
-    const bound = [ftsQuery, ...provParams];
-    return db.prepare(provSql).all(...bound) as ProvisionHit[];
-  };
+    if (resolvedDocId) {
+      provSql += ' AND lp.document_id = ?';
+      provParams.push(resolvedDocId);
+    }
 
-  let provisions = runProvisionQuery(queryVariants.primary);
-  if (provisions.length === 0 && queryVariants.fallback) {
-    provisions = runProvisionQuery(queryVariants.fallback);
+    provSql += ' ORDER BY relevance LIMIT ?';
+    provParams.push(fetchLimit);
+
+    try {
+      const rows = db.prepare(provSql).all(...provParams) as ProvisionHit[];
+      if (rows.length > 0) {
+        queryStrategy = ftsQuery === queryVariants[0] ? 'exact' : 'fallback';
+        const provisions = deduplicateResults(rows, limit);
+        return {
+          results: {
+            query: input.query,
+            provisions,
+            total_citations: provisions.length,
+          },
+          _metadata: {
+            ...generateResponseMetadata(db),
+            ...(queryStrategy === 'fallback' ? { query_strategy: 'broadened' } : {}),
+          },
+        };
+      }
+    } catch {
+      // FTS query syntax error — try next variant
+      continue;
+    }
+  }
+
+  // LIKE fallback — final tier when FTS5 returns no results
+  {
+    const likePattern = buildLikePattern(sanitizeFtsInput(input.query));
+    let likeSql = `
+      SELECT
+        lp.document_id,
+        ld.title as document_title,
+        lp.provision_ref,
+        lp.title,
+        substr(lp.content, 1, 200) as snippet,
+        0 as relevance
+      FROM legal_provisions lp
+      JOIN legal_documents ld ON ld.id = lp.document_id
+      WHERE lp.content LIKE ?
+    `;
+    const likeParams: (string | number)[] = [likePattern];
+
+    if (resolvedDocId) {
+      likeSql += ' AND lp.document_id = ?';
+      likeParams.push(resolvedDocId);
+    }
+
+    likeSql += ' LIMIT ?';
+    likeParams.push(fetchLimit);
+
+    try {
+      const rows = db.prepare(likeSql).all(...likeParams) as ProvisionHit[];
+      if (rows.length > 0) {
+        const provisions = deduplicateResults(rows, limit);
+        return {
+          results: {
+            query: input.query,
+            provisions,
+            total_citations: provisions.length,
+          },
+          _metadata: {
+            ...generateResponseMetadata(db),
+            query_strategy: 'like_fallback',
+          },
+        };
+      }
+    } catch {
+      // LIKE query failed
+    }
   }
 
   return {
-    results: {
-      query: input.query,
-      provisions,
-      total_citations: provisions.length,
-    },
-    _metadata: generateResponseMetadata(db)
+    results: { query: input.query, provisions: [], total_citations: 0 },
+    _metadata: generateResponseMetadata(db),
   };
+}
+
+/**
+ * Deduplicate results by document_title + provision_ref.
+ * Duplicate document IDs (numeric vs slug) cause the same provision to appear twice.
+ * Keeps the first (highest-ranked) occurrence.
+ */
+function deduplicateResults(
+  rows: ProvisionHit[],
+  limit: number,
+): ProvisionHit[] {
+  const seen = new Set<string>();
+  const deduped: ProvisionHit[] = [];
+  for (const row of rows) {
+    const key = `${row.document_title}::${row.provision_ref}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(row);
+    if (deduped.length >= limit) break;
+  }
+  return deduped;
 }

--- a/src/tools/search-legislation.ts
+++ b/src/tools/search-legislation.ts
@@ -3,8 +3,9 @@
  */
 
 import type { Database } from '@ansvar/mcp-sqlite';
-import { buildFtsQueryVariantsLegacy as buildFtsQueryVariants } from '../utils/fts-query.js';
+import { buildFtsQueryVariants, buildLikePattern, sanitizeFtsInput } from '../utils/fts-query.js';
 import { normalizeAsOfDate } from '../utils/as-of-date.js';
+import { resolveDocumentId } from '../utils/statute-id.js';
 import { generateResponseMetadata, type ToolResponse } from '../utils/metadata.js';
 
 export interface SearchLegislationInput {
@@ -31,63 +32,154 @@ const MAX_LIMIT = 50;
 
 export async function searchLegislation(
   db: Database,
-  input: SearchLegislationInput
+  input: SearchLegislationInput,
 ): Promise<ToolResponse<SearchLegislationResult[]>> {
   if (!input.query || input.query.trim().length === 0) {
-    return {
-      results: [],
-      _metadata: generateResponseMetadata(db)
-    };
+    return { results: [], _metadata: generateResponseMetadata(db) };
   }
 
   const limit = Math.min(Math.max(input.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
-  const queryVariants = buildFtsQueryVariants(input.query);
+  // Fetch extra rows to account for deduplication
+  const fetchLimit = limit * 2;
+  const queryVariants = buildFtsQueryVariants(sanitizeFtsInput(input.query));
   // Validate as_of_date if provided (throws on invalid format)
   if (input.as_of_date) normalizeAsOfDate(input.as_of_date);
 
-  let sql = `
-    SELECT
-      lp.document_id,
-      ld.title as document_title,
-      lp.provision_ref,
-      lp.chapter,
-      lp.section,
-      lp.title,
-      snippet(provisions_fts, 0, '>>>', '<<<', '...', 32) as snippet,
-      bm25(provisions_fts) as relevance
-    FROM provisions_fts
-    JOIN legal_provisions lp ON lp.id = provisions_fts.rowid
-    JOIN legal_documents ld ON ld.id = lp.document_id
-    WHERE provisions_fts MATCH ?
-  `;
-
-  const params: (string | number)[] = [];
-
+  // Resolve document_id from title if provided (same resolution as get_provision)
+  let resolvedDocId: string | undefined;
   if (input.document_id) {
-    sql += ` AND lp.document_id = ?`;
-    params.push(input.document_id);
+    const resolved = resolveDocumentId(db, input.document_id);
+    resolvedDocId = resolved ?? undefined;
+    if (!resolved) {
+      return {
+        results: [],
+        _metadata: {
+          ...generateResponseMetadata(db),
+          note: `No document found matching "${input.document_id}"`,
+        },
+      };
+    }
   }
 
-  if (input.status) {
-    sql += ` AND ld.status = ?`;
-    params.push(input.status);
+  let queryStrategy = 'none';
+  for (const ftsQuery of queryVariants) {
+    let sql = `
+      SELECT
+        lp.document_id,
+        ld.title as document_title,
+        lp.provision_ref,
+        lp.chapter,
+        lp.section,
+        lp.title,
+        snippet(provisions_fts, 0, '>>>', '<<<', '...', 32) as snippet,
+        bm25(provisions_fts) as relevance
+      FROM provisions_fts
+      JOIN legal_provisions lp ON lp.id = provisions_fts.rowid
+      JOIN legal_documents ld ON ld.id = lp.document_id
+      WHERE provisions_fts MATCH ?
+    `;
+    const params: (string | number)[] = [ftsQuery];
+
+    if (resolvedDocId) {
+      sql += ' AND lp.document_id = ?';
+      params.push(resolvedDocId);
+    }
+
+    if (input.status) {
+      sql += ' AND ld.status = ?';
+      params.push(input.status);
+    }
+
+    sql += ' ORDER BY relevance LIMIT ?';
+    params.push(fetchLimit);
+
+    try {
+      const rows = db.prepare(sql).all(...params) as SearchLegislationResult[];
+      if (rows.length > 0) {
+        queryStrategy = ftsQuery === queryVariants[0] ? 'exact' : 'fallback';
+        const deduped = deduplicateResults(rows, limit);
+        return {
+          results: deduped,
+          _metadata: {
+            ...generateResponseMetadata(db),
+            ...(queryStrategy === 'fallback' ? { query_strategy: 'broadened' } : {}),
+          },
+        };
+      }
+    } catch {
+      // FTS query syntax error — try next variant
+      continue;
+    }
   }
 
-  sql += ` ORDER BY relevance LIMIT ?`;
-  params.push(limit);
+  // LIKE fallback — final tier when FTS5 returns no results
+  {
+    const likePattern = buildLikePattern(sanitizeFtsInput(input.query));
+    let likeSql = `
+      SELECT
+        lp.document_id,
+        ld.title as document_title,
+        lp.provision_ref,
+        lp.chapter,
+        lp.section,
+        lp.title,
+        substr(lp.content, 1, 200) as snippet,
+        0 as relevance
+      FROM legal_provisions lp
+      JOIN legal_documents ld ON ld.id = lp.document_id
+      WHERE lp.content LIKE ?
+    `;
+    const likeParams: (string | number)[] = [likePattern];
 
-  const runQuery = (ftsQuery: string): SearchLegislationResult[] => {
-    const bound = [ftsQuery, ...params];
-    return db.prepare(sql).all(...bound) as SearchLegislationResult[];
-  };
+    if (resolvedDocId) {
+      likeSql += ' AND lp.document_id = ?';
+      likeParams.push(resolvedDocId);
+    }
 
-  const primaryResults = runQuery(queryVariants.primary);
-  const results = (primaryResults.length > 0 || !queryVariants.fallback)
-    ? primaryResults
-    : runQuery(queryVariants.fallback);
+    if (input.status) {
+      likeSql += ' AND ld.status = ?';
+      likeParams.push(input.status);
+    }
 
-  return {
-    results,
-    _metadata: generateResponseMetadata(db)
-  };
+    likeSql += ' LIMIT ?';
+    likeParams.push(fetchLimit);
+
+    try {
+      const rows = db.prepare(likeSql).all(...likeParams) as SearchLegislationResult[];
+      if (rows.length > 0) {
+        return {
+          results: deduplicateResults(rows, limit),
+          _metadata: {
+            ...generateResponseMetadata(db),
+            query_strategy: 'like_fallback',
+          },
+        };
+      }
+    } catch {
+      // LIKE query failed
+    }
+  }
+
+  return { results: [], _metadata: generateResponseMetadata(db) };
+}
+
+/**
+ * Deduplicate search results by document_title + provision_ref.
+ * Duplicate document IDs (numeric vs slug) cause the same provision to appear twice.
+ * Keeps the first (highest-ranked) occurrence.
+ */
+function deduplicateResults(
+  rows: SearchLegislationResult[],
+  limit: number,
+): SearchLegislationResult[] {
+  const seen = new Set<string>();
+  const deduped: SearchLegislationResult[] = [];
+  for (const row of rows) {
+    const key = `${row.document_title}::${row.provision_ref}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(row);
+    if (deduped.length >= limit) break;
+  }
+  return deduped;
 }

--- a/src/utils/fts-query.ts
+++ b/src/utils/fts-query.ts
@@ -59,9 +59,10 @@ export function sanitizeFtsInput(input: string): string {
     return input.replace(/[{}[\]^~*:]/g, ' ').replace(/\s+/g, ' ').trim();
   }
 
-  // Standard mode: aggressive strip
+  // Standard mode: aggressive strip — preserve trailing * for FTS5 prefix search
   const cleaned = input
-    .replace(/['"(){}[\]^~*:@#$%&+=<>|\\/.!?,;]/g, ' ')
+    .replace(/['"(){}[\]^~:@#$%&+=<>|\\/.!?,;]/g, ' ')
+    .replace(/\*(?!\s|$)/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
 

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -8,6 +8,8 @@ export interface ResponseMetadata {
   data_freshness: string;
   disclaimer: string;
   source_authority: string;
+  note?: string;
+  query_strategy?: string;
 }
 
 export interface ToolResponse<T> {

--- a/tests/utils/fts-query.test.ts
+++ b/tests/utils/fts-query.test.ts
@@ -1,23 +1,33 @@
 import { describe, it, expect } from 'vitest';
-import { buildFtsQueryVariants } from '../../src/utils/fts-query.js';
+import { buildFtsQueryVariants, sanitizeFtsInput } from '../../src/utils/fts-query.js';
 
 describe('buildFtsQueryVariants', () => {
-  it('keeps explicit FTS syntax unchanged', () => {
+  it('keeps explicit FTS syntax unchanged (boolean passthrough)', () => {
     const query = '"data protection" AND processing';
-    const built = buildFtsQueryVariants(query);
-    expect(built.primary).toBe(query);
-    expect(built.fallback).toBeUndefined();
+    const sanitized = sanitizeFtsInput(query);
+    const variants = buildFtsQueryVariants(sanitized);
+    expect(variants).toHaveLength(1);
+    expect(variants[0]).toBe(sanitized);
   });
 
-  it('builds prefix and fallback OR variants for plain terms', () => {
-    const built = buildFtsQueryVariants('data protection');
-    expect(built.primary).toBe('"data"* "protection"*');
-    expect(built.fallback).toBe('data* OR protection*');
+  it('builds multiple variants for plain terms', () => {
+    const variants = buildFtsQueryVariants(sanitizeFtsInput('data protection'));
+    expect(variants.length).toBeGreaterThanOrEqual(2);
+    // First variant should be exact phrase
+    expect(variants[0]).toBe('"data protection"');
+    // Last variant should be broadest (OR)
+    expect(variants[variants.length - 1]).toBe('data OR protection');
   });
 
   it('removes punctuation from non-explicit queries', () => {
-    const built = buildFtsQueryVariants('criminal, fraud!');
-    expect(built.primary).toBe('"criminal"* "fraud"*');
-    expect(built.fallback).toBe('criminal* OR fraud*');
+    const variants = buildFtsQueryVariants(sanitizeFtsInput('criminal, fraud!'));
+    expect(variants.length).toBeGreaterThanOrEqual(2);
+    // First variant should be exact phrase
+    expect(variants[0]).toBe('"criminal fraud"');
+  });
+
+  it('preserves trailing wildcard for prefix search', () => {
+    const sanitized = sanitizeFtsInput('protect*');
+    expect(sanitized).toContain('*');
   });
 });


### PR DESCRIPTION
## Summary
- **P0**: Deduplicate search results by `document_title + provision_ref` in `search-legislation.ts` and `build-legal-stance.ts` — fetch `limit * 2` rows then deduplicate
- **P1**: Preserve trailing `*` on words in `sanitizeFtsInput()` for FTS5 prefix search
- **P1**: Import and use `resolveDocumentId` in search/stance tools before querying, returning a `note` when no document matches
- **P2**: Add `query_strategy: 'broadened'` to `_metadata` when fallback triggers; `like_fallback` for LIKE tier
- **CI**: Add `note?` and `query_strategy?` optional fields to `ResponseMetadata` interface

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` — 21/21 tests pass
- [x] Updated `fts-query.test.ts` to match new `string[]` return type

Generated with [Claude Code](https://claude.com/claude-code)