### PR TITLE
fix: accept article param in get_provision for fleet audit compatibility

### DIFF
--- a/src/tools/get-provision.ts
+++ b/src/tools/get-provision.ts
@@ -11,6 +11,7 @@ export interface GetProvisionInput {
   part?: string;
   chapter?: string;
   section?: string;
+  article?: string;
   provision_ref?: string;
 }
 
@@ -46,7 +47,7 @@ export async function getProvision(
 
   const resolvedDocumentId = resolveExistingStatuteId(db, input.document_id) ?? input.document_id;
 
-  const provisionRef = input.provision_ref ?? input.section;
+  const provisionRef = input.provision_ref ?? input.section ?? (input as any).article;
 
   // If no specific provision, return all provisions for the document
   if (!provisionRef) {

--- a/src/utils/statute-id.ts
+++ b/src/utils/statute-id.ts
@@ -116,6 +116,7 @@ export function resolveDocumentId(
   db: Db,
   input: string,
 ): string | null {
+  if (!input || typeof input !== 'string') return null;
   const trimmed = input.trim();
   if (!trimmed) return null;
 


### PR DESCRIPTION
## Summary

- Add `article?: string` to `GetProvisionInput` interface
- Extend provision ref resolution: `provision_ref ?? section ?? article`
- Add null/type guard before `.trim()` in `resolveDocumentId` in `statute-id.ts`

## Why

The fleet audit sends `{"document_id": "...", "article": "1"}` but `get_provision` previously ignored the `article` field, returning no result. This fix makes the tool accept `article` as an alias for `section`.

## Test plan
- `npm run typecheck` passes (tsc --noEmit -p tsconfig.check.json)
- 21/21 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)