### PR TITLE
fix: accept article param in get_provision for fleet audit compatibility

### DIFF
--- a/src/tools/get-provision.ts
+++ b/src/tools/get-provision.ts
@@ -11,6 +11,7 @@ export interface GetProvisionInput {
   part?: string;
   chapter?: string;
   section?: string;
+  article?: string;
   provision_ref?: string;
 }
 
@@ -46,7 +47,7 @@ export async function getProvision(
 
   const resolvedDocumentId = resolveExistingStatuteId(db, input.document_id) ?? input.document_id;
 
-  const provisionRef = input.provision_ref ?? input.section;
+  const provisionRef = input.provision_ref ?? input.section ?? (input as any).article;
 
   // If no specific provision, return all provisions for the document
   if (!provisionRef) {

--- a/src/utils/statute-id.ts
+++ b/src/utils/statute-id.ts
@@ -116,6 +116,7 @@ export function resolveDocumentId(
   db: Db,
   input: string,
 ): string | null {
+  if (!input || typeof input !== 'string') return null;
   const trimmed = input.trim();
   if (!trimmed) return null;
 


### PR DESCRIPTION
## Summary

- Add `article?: string` to `GetProvisionInput` interface
- Extend provision ref resolution chain: `provision_ref ?? section ?? article`
- Add null/type guard before `.trim()` in `resolveDocumentId`

Fixes fleet audit failures where `{"document_id": "...", "article": "1"}` calls to `get_provision` returned no results because the `article` field was ignored.

Squash-merged from `fix/get-provision-article-field` → `dev` (PR #43).

🤖 Generated with [Claude Code](https://claude.com/claude-code)