### PR TITLE
fix: fleet compliance gaps — _meta, _citation, error_type, search_preparatory_works, monthly-rebuild

### DIFF
--- a/.github/workflows/monthly-rebuild.yml
+++ b/.github/workflows/monthly-rebuild.yml
@@ -1,0 +1,61 @@
+name: Monthly Rebuild
+
+on:
+  schedule:
+    - cron: '0 2 1 * *'
+  workflow_dispatch:
+
+concurrency:
+  group: monthly-rebuild
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Ingest latest data
+        run: npm run ingest
+
+      - name: Build TypeScript
+        run: npm run build
+
+      - name: Commit updated database
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -f data/
+          if git diff --cached --quiet; then
+            echo "No database changes to commit"
+          else
+            git commit -m "chore: monthly database rebuild $(date -u '+%Y-%m-%d')"
+            git push
+          fi
+
+      - name: Trigger deploy
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'vercel-deploy.yml',
+              ref: context.ref,
+            });

--- a/src/tools/build-legal-stance.ts
+++ b/src/tools/build-legal-stance.ts
@@ -5,7 +5,7 @@
 import type { Database } from '@ansvar/mcp-sqlite';
 import { buildFtsQueryVariants, buildLikePattern, sanitizeFtsInput } from '../utils/fts-query.js';
 import { resolveDocumentId } from '../utils/statute-id.js';
-import { generateResponseMetadata, type ToolResponse } from '../utils/metadata.js';
+import { generateResponseMetadata, type ToolResponse, type Citation } from '../utils/metadata.js';
 
 export interface BuildLegalStanceInput {
   query: string;
@@ -23,6 +23,7 @@ interface ProvisionHit {
   title: string | null;
   snippet: string;
   relevance: number;
+  _citation: Citation;
 }
 
 export interface LegalStanceResult {
@@ -34,6 +35,29 @@ export interface LegalStanceResult {
 const DEFAULT_LIMIT = 5;
 const MAX_LIMIT = 20;
 
+interface RawProvisionHit {
+  document_id: string;
+  document_title: string;
+  provision_ref: string;
+  title: string | null;
+  snippet: string;
+  relevance: number;
+}
+
+function buildItemCitation(row: RawProvisionHit): Citation {
+  return {
+    canonical_ref: `${row.document_id}/${row.provision_ref}`,
+    display_text: row.title
+      ? `${row.title}, ${row.document_title}`
+      : `${row.provision_ref}, ${row.document_title}`,
+    lookup: { tool: 'get_provision', params: { document_id: row.document_id, provision_ref: row.provision_ref } },
+  };
+}
+
+function addCitations(rows: RawProvisionHit[]): ProvisionHit[] {
+  return rows.map(row => ({ ...row, _citation: buildItemCitation(row) }));
+}
+
 export async function buildLegalStance(
   db: Database,
   input: BuildLegalStanceInput,
@@ -41,7 +65,7 @@ export async function buildLegalStance(
   if (!input.query || input.query.trim().length === 0) {
     return {
       results: { query: '', provisions: [], total_citations: 0 },
-      _metadata: generateResponseMetadata(db),
+      _meta: generateResponseMetadata(db),
     };
   }
 
@@ -58,7 +82,7 @@ export async function buildLegalStance(
     if (!resolved) {
       return {
         results: { query: input.query, provisions: [], total_citations: 0 },
-        _metadata: {
+        _meta: {
           ...generateResponseMetadata(db),
           note: `No document found matching "${input.document_id}"`,
         },
@@ -92,17 +116,17 @@ export async function buildLegalStance(
     provParams.push(fetchLimit);
 
     try {
-      const rows = db.prepare(provSql).all(...provParams) as ProvisionHit[];
+      const rows = db.prepare(provSql).all(...provParams) as RawProvisionHit[];
       if (rows.length > 0) {
         queryStrategy = ftsQuery === queryVariants[0] ? 'exact' : 'fallback';
-        const provisions = deduplicateResults(rows, limit);
+        const provisions = addCitations(deduplicateResults(rows, limit));
         return {
           results: {
             query: input.query,
             provisions,
             total_citations: provisions.length,
           },
-          _metadata: {
+          _meta: {
             ...generateResponseMetadata(db),
             ...(queryStrategy === 'fallback' ? { query_strategy: 'broadened' } : {}),
           },
@@ -140,16 +164,16 @@ export async function buildLegalStance(
     likeParams.push(fetchLimit);
 
     try {
-      const rows = db.prepare(likeSql).all(...likeParams) as ProvisionHit[];
+      const rows = db.prepare(likeSql).all(...likeParams) as RawProvisionHit[];
       if (rows.length > 0) {
-        const provisions = deduplicateResults(rows, limit);
+        const provisions = addCitations(deduplicateResults(rows, limit));
         return {
           results: {
             query: input.query,
             provisions,
             total_citations: provisions.length,
           },
-          _metadata: {
+          _meta: {
             ...generateResponseMetadata(db),
             query_strategy: 'like_fallback',
           },
@@ -162,7 +186,7 @@ export async function buildLegalStance(
 
   return {
     results: { query: input.query, provisions: [], total_citations: 0 },
-    _metadata: generateResponseMetadata(db),
+    _meta: generateResponseMetadata(db),
   };
 }
 
@@ -172,11 +196,11 @@ export async function buildLegalStance(
  * Keeps the first (highest-ranked) occurrence.
  */
 function deduplicateResults(
-  rows: ProvisionHit[],
+  rows: RawProvisionHit[],
   limit: number,
-): ProvisionHit[] {
+): RawProvisionHit[] {
   const seen = new Set<string>();
-  const deduped: ProvisionHit[] = [];
+  const deduped: RawProvisionHit[] = [];
   for (const row of rows) {
     const key = `${row.document_title}::${row.provision_ref}`;
     if (seen.has(key)) continue;

--- a/src/tools/check-currency.ts
+++ b/src/tools/check-currency.ts
@@ -50,7 +50,7 @@ export async function checkCurrency(
   if (!doc) {
     return {
       results: null,
-      _metadata: generateResponseMetadata(db)
+      _meta: generateResponseMetadata(db)
     };
   }
 
@@ -85,6 +85,6 @@ export async function checkCurrency(
       provision_exists: provisionExists,
       warnings,
     },
-    _metadata: generateResponseMetadata(db)
+    _meta: generateResponseMetadata(db)
   };
 }

--- a/src/tools/format-citation.ts
+++ b/src/tools/format-citation.ts
@@ -26,7 +26,7 @@ export async function formatCitationTool(
   if (!input.citation || input.citation.trim().length === 0) {
     return {
       results: { input: '', formatted: '', type: 'unknown', valid: false, error: 'Empty citation' },
-      _metadata: generateResponseMetadata()
+      _meta: generateResponseMetadata()
     };
   }
 
@@ -41,7 +41,7 @@ export async function formatCitationTool(
         valid: false,
         error: parsed.error,
       },
-      _metadata: generateResponseMetadata()
+      _meta: generateResponseMetadata()
     };
   }
 
@@ -54,6 +54,6 @@ export async function formatCitationTool(
       type: parsed.type,
       valid: true,
     },
-    _metadata: generateResponseMetadata()
+    _meta: generateResponseMetadata()
   };
 }

--- a/src/tools/get-eu-basis.ts
+++ b/src/tools/get-eu-basis.ts
@@ -4,7 +4,7 @@
 
 import type { Database } from '@ansvar/mcp-sqlite';
 import type { EUBasisDocument } from '../types/index.js';
-import { generateResponseMetadata, type ToolResponse } from '../utils/metadata.js';
+import { generateResponseMetadata, type ToolResponse, type Citation } from '../utils/metadata.js';
 import { resolveExistingStatuteId } from '../utils/statute-id.js';
 
 export interface GetEUBasisInput {
@@ -13,10 +13,12 @@ export interface GetEUBasisInput {
   reference_types?: string[];
 }
 
+export type EUBasisDocumentWithCitation = EUBasisDocument & { _citation: Citation };
+
 export interface GetEUBasisResult {
   document_id: string;
   document_title: string;
-  eu_documents: EUBasisDocument[];
+  eu_documents: EUBasisDocumentWithCitation[];
   statistics: {
     total_eu_references: number;
     directive_count: number;
@@ -41,7 +43,7 @@ export async function getEUBasis(
         eu_documents: [],
         statistics: { total_eu_references: 0, directive_count: 0, regulation_count: 0 },
       },
-      _metadata: generateResponseMetadata(db),
+      _meta: generateResponseMetadata(db),
     };
   }
 
@@ -78,11 +80,16 @@ export async function getEUBasis(
 
   const rows = db.prepare(sql).all(...params) as QueryRow[];
 
-  const euDocuments: EUBasisDocument[] = rows.map(row => {
-    const result: EUBasisDocument = {
+  const euDocuments: EUBasisDocumentWithCitation[] = rows.map(row => {
+    const result: EUBasisDocumentWithCitation = {
       id: row.id, type: row.type, year: row.year, number: row.number,
       community: row.community as any, reference_type: row.reference_type as any,
       is_primary_implementation: row.is_primary_implementation === 1,
+      _citation: {
+        canonical_ref: row.id,
+        display_text: row.title ?? row.short_name ?? row.id,
+        lookup: { tool: 'get_eu_basis', params: { document_id: doc.id } },
+      },
     };
     if (row.celex_number) result.celex_number = row.celex_number;
     if (row.title) result.title = row.title;
@@ -105,6 +112,6 @@ export async function getEUBasis(
         regulation_count: euDocuments.filter(d => d.type === 'regulation').length,
       },
     },
-    _metadata: generateResponseMetadata(db),
+    _meta: generateResponseMetadata(db),
   };
 }

--- a/src/tools/get-irish-implementations.ts
+++ b/src/tools/get-irish-implementations.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Database } from '@ansvar/mcp-sqlite';
-import { generateResponseMetadata, type ToolResponse } from '../utils/metadata.js';
+import { generateResponseMetadata, type ToolResponse, type Citation } from '../utils/metadata.js';
 
 export interface GetIrishImplementationsInput {
   eu_document_id: string;
@@ -20,6 +20,7 @@ export interface GetIrishImplementationsResult {
     status: string;
     reference_type: string;
     is_primary: boolean;
+    _citation: Citation;
   }>;
   total: number;
 }
@@ -95,12 +96,21 @@ export async function getIrishImplementations(
     existing.is_primary = existing.is_primary || incomingIsPrimary;
   }
 
-  const implementations = Array.from(byDocument.values()).sort((a, b) => {
-    if (a.is_primary !== b.is_primary) {
-      return a.is_primary ? -1 : 1;
-    }
-    return a.title.localeCompare(b.title);
-  });
+  const implementations = Array.from(byDocument.values())
+    .sort((a, b) => {
+      if (a.is_primary !== b.is_primary) {
+        return a.is_primary ? -1 : 1;
+      }
+      return a.title.localeCompare(b.title);
+    })
+    .map(impl => ({
+      ...impl,
+      _citation: {
+        canonical_ref: impl.document_id,
+        display_text: impl.title,
+        lookup: { tool: 'get_provision', params: { document_id: impl.document_id } },
+      } as Citation,
+    }));
 
   return {
     results: {
@@ -109,6 +119,6 @@ export async function getIrishImplementations(
       implementations,
       total: implementations.length,
     },
-    _metadata: generateResponseMetadata(db),
+    _meta: generateResponseMetadata(db),
   };
 }

--- a/src/tools/get-provision-eu-basis.ts
+++ b/src/tools/get-provision-eu-basis.ts
@@ -38,7 +38,7 @@ export async function getProvisionEUBasis(
         provision_ref: input.provision_ref,
         eu_references: [],
       },
-      _metadata: generateResponseMetadata(db),
+      _meta: generateResponseMetadata(db),
     };
   }
 
@@ -53,7 +53,7 @@ export async function getProvisionEUBasis(
         provision_ref: input.provision_ref,
         eu_references: [],
       },
-      _metadata: generateResponseMetadata(db),
+      _meta: generateResponseMetadata(db),
     };
   }
 
@@ -92,6 +92,11 @@ export async function getProvisionEUBasis(
         return ref;
       }),
     },
-    _metadata: generateResponseMetadata(db),
+    _meta: generateResponseMetadata(db),
+    _citation: {
+      canonical_ref: `${resolvedId}/${input.provision_ref}`,
+      display_text: `${input.provision_ref}, ${resolvedId}`,
+      lookup: { tool: 'get_provision_eu_basis', params: { document_id: resolvedId, provision_ref: input.provision_ref } },
+    },
   };
 }

--- a/src/tools/get-provision.ts
+++ b/src/tools/get-provision.ts
@@ -4,7 +4,7 @@
 
 import type { Database } from '@ansvar/mcp-sqlite';
 import { resolveExistingStatuteId } from '../utils/statute-id.js';
-import { generateResponseMetadata, type ToolResponse } from '../utils/metadata.js';
+import { generateResponseMetadata, type ToolResponse, type Citation } from '../utils/metadata.js';
 
 export interface GetProvisionInput {
   document_id: string;
@@ -35,6 +35,16 @@ interface ProvisionRow {
   section: string;
   title: string | null;
   content: string;
+}
+
+function buildProvisionCitation(row: ProvisionRow): Citation {
+  return {
+    canonical_ref: `${row.document_id}/${row.provision_ref}`,
+    display_text: row.title
+      ? `${row.title}, ${row.document_title}`
+      : `${row.provision_ref}, ${row.document_title}`,
+    lookup: { tool: 'get_provision', params: { document_id: row.document_id, provision_ref: row.provision_ref } },
+  };
 }
 
 export async function getProvision(
@@ -69,7 +79,10 @@ export async function getProvision(
 
     return {
       results: rows,
-      _metadata: generateResponseMetadata(db)
+      _meta: generateResponseMetadata(db),
+      _citation: rows.length > 0
+        ? { canonical_ref: resolvedDocumentId, display_text: rows[0].document_title, lookup: { tool: 'get_provision', params: { document_id: resolvedDocumentId } } }
+        : undefined,
     };
   }
 
@@ -91,12 +104,13 @@ export async function getProvision(
   if (!row) {
     return {
       results: null,
-      _metadata: generateResponseMetadata(db)
+      _meta: generateResponseMetadata(db)
     };
   }
 
   return {
     results: row,
-    _metadata: generateResponseMetadata(db)
+    _meta: generateResponseMetadata(db),
+    _citation: buildProvisionCitation(row),
   };
 }

--- a/src/tools/list-sources.ts
+++ b/src/tools/list-sources.ts
@@ -96,6 +96,6 @@ export function listSources(db: InstanceType<typeof Database>): ToolResponse<Lis
         built_at: meta.built_at ?? null,
       },
     },
-    _metadata: generateResponseMetadata(db),
+    _meta: generateResponseMetadata(db),
   };
 }

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -10,6 +10,7 @@ import {
   Tool,
 } from '@modelcontextprotocol/sdk/types.js';
 import Database from '@ansvar/mcp-sqlite';
+import { generateResponseMetadata } from '../utils/metadata.js';
 
 import { searchLegislation, SearchLegislationInput } from './search-legislation.js';
 import { getProvision, GetProvisionInput } from './get-provision.js';
@@ -24,6 +25,7 @@ import { getProvisionEUBasis, GetProvisionEUBasisInput } from './get-provision-e
 import { validateEUCompliance, ValidateEUComplianceInput } from './validate-eu-compliance.js';
 import { listSources } from './list-sources.js';
 import { getAbout, type AboutContext } from './about.js';
+import { searchPreparatoryWorks, SearchPreparatoryWorksInput } from './search-preparatory-works.js';
 export type { AboutContext } from './about.js';
 
 const ABOUT_TOOL: Tool = {
@@ -339,6 +341,39 @@ export const TOOLS: Tool[] = [
     },
   },
   {
+    name: 'search_preparatory_works',
+    description:
+      'Search Irish legislative preparatory materials (explanatory memoranda, draft bills, committee reports). ' +
+      'Returns: id, document_id, title, type, and content for matching preparatory works. ' +
+      'Requires a professional-tier database; returns an upgrade notice on free-tier databases. ' +
+      'Use this to trace the legislative intent and history behind Irish statutes.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Search query across preparatory work titles and content.',
+        },
+        document_id: {
+          type: 'string',
+          description: 'Filter to a specific statute by its identifier (e.g., "act-2018-7").',
+        },
+        type: {
+          type: 'string',
+          description: 'Filter by material type (e.g., "memo", "draft", "report").',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum results. Default: 10, maximum: 50.',
+          default: 10,
+          minimum: 1,
+          maximum: 50,
+        },
+      },
+      required: ['query'],
+    },
+  },
+  {
     name: 'validate_eu_compliance',
     description:
       'Validate the EU compliance status of an Irish statute or provision. ' +
@@ -422,6 +457,9 @@ export function registerTools(
         case 'get_provision_eu_basis':
           result = await getProvisionEUBasis(db, args as unknown as GetProvisionEUBasisInput);
           break;
+        case 'search_preparatory_works':
+          result = await searchPreparatoryWorks(db, args as unknown as SearchPreparatoryWorksInput);
+          break;
         case 'validate_eu_compliance':
           result = await validateEUCompliance(db, args as unknown as ValidateEUComplianceInput);
           break;
@@ -448,7 +486,7 @@ export function registerTools(
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       return {
-        content: [{ type: 'text', text: `Error: ${message}` }],
+        content: [{ type: 'text', text: JSON.stringify({ error: message, _error_type: 'tool_execution_error', _meta: generateResponseMetadata(db) }, null, 2) }],
         isError: true,
       };
     }

--- a/src/tools/search-eu-implementations.ts
+++ b/src/tools/search-eu-implementations.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Database } from '@ansvar/mcp-sqlite';
-import { generateResponseMetadata, type ToolResponse } from '../utils/metadata.js';
+import { generateResponseMetadata, type ToolResponse, type Citation } from '../utils/metadata.js';
 
 export interface SearchEUImplementationsInput {
   query?: string;
@@ -23,6 +23,7 @@ export interface SearchEUImplementationsResult {
     };
     irish_statute_count: number;
     primary_implementations: string[];
+    _citation: Citation;
   }>;
   total_results: number;
 }
@@ -84,9 +85,14 @@ export async function searchEUImplementations(
         },
         irish_statute_count: r.irish_statute_count,
         primary_implementations: r.primary_implementations?.split(',').filter(Boolean) ?? [],
+        _citation: {
+          canonical_ref: r.id,
+          display_text: r.title ?? r.short_name ?? r.id,
+          lookup: { tool: 'get_irish_implementations', params: { eu_document_id: r.id } },
+        } as Citation,
       })),
       total_results: rows.length,
     },
-    _metadata: generateResponseMetadata(db),
+    _meta: generateResponseMetadata(db),
   };
 }

--- a/src/tools/search-legislation.ts
+++ b/src/tools/search-legislation.ts
@@ -6,7 +6,7 @@ import type { Database } from '@ansvar/mcp-sqlite';
 import { buildFtsQueryVariants, buildLikePattern, sanitizeFtsInput } from '../utils/fts-query.js';
 import { normalizeAsOfDate } from '../utils/as-of-date.js';
 import { resolveDocumentId } from '../utils/statute-id.js';
-import { generateResponseMetadata, type ToolResponse } from '../utils/metadata.js';
+import { generateResponseMetadata, type ToolResponse, type Citation } from '../utils/metadata.js';
 
 export interface SearchLegislationInput {
   query: string;
@@ -25,17 +25,32 @@ export interface SearchLegislationResult {
   title: string | null;
   snippet: string;
   relevance: number;
+  _citation: Citation;
 }
 
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 50;
+
+function buildItemCitation(row: Omit<SearchLegislationResult, '_citation'>): Citation {
+  return {
+    canonical_ref: `${row.document_id}/${row.provision_ref}`,
+    display_text: row.title
+      ? `${row.title}, ${row.document_title}`
+      : `${row.provision_ref}, ${row.document_title}`,
+    lookup: { tool: 'get_provision', params: { document_id: row.document_id, provision_ref: row.provision_ref } },
+  };
+}
+
+function addCitations(rows: Omit<SearchLegislationResult, '_citation'>[]): SearchLegislationResult[] {
+  return rows.map(row => ({ ...row, _citation: buildItemCitation(row) }));
+}
 
 export async function searchLegislation(
   db: Database,
   input: SearchLegislationInput,
 ): Promise<ToolResponse<SearchLegislationResult[]>> {
   if (!input.query || input.query.trim().length === 0) {
-    return { results: [], _metadata: generateResponseMetadata(db) };
+    return { results: [], _meta: generateResponseMetadata(db) };
   }
 
   const limit = Math.min(Math.max(input.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
@@ -53,7 +68,7 @@ export async function searchLegislation(
     if (!resolved) {
       return {
         results: [],
-        _metadata: {
+        _meta: {
           ...generateResponseMetadata(db),
           note: `No document found matching "${input.document_id}"`,
         },
@@ -94,13 +109,13 @@ export async function searchLegislation(
     params.push(fetchLimit);
 
     try {
-      const rows = db.prepare(sql).all(...params) as SearchLegislationResult[];
+      const rows = db.prepare(sql).all(...params) as Omit<SearchLegislationResult, '_citation'>[];
       if (rows.length > 0) {
         queryStrategy = ftsQuery === queryVariants[0] ? 'exact' : 'fallback';
         const deduped = deduplicateResults(rows, limit);
         return {
-          results: deduped,
-          _metadata: {
+          results: addCitations(deduped),
+          _meta: {
             ...generateResponseMetadata(db),
             ...(queryStrategy === 'fallback' ? { query_strategy: 'broadened' } : {}),
           },
@@ -145,11 +160,11 @@ export async function searchLegislation(
     likeParams.push(fetchLimit);
 
     try {
-      const rows = db.prepare(likeSql).all(...likeParams) as SearchLegislationResult[];
+      const rows = db.prepare(likeSql).all(...likeParams) as Omit<SearchLegislationResult, '_citation'>[];
       if (rows.length > 0) {
         return {
-          results: deduplicateResults(rows, limit),
-          _metadata: {
+          results: addCitations(deduplicateResults(rows, limit)),
+          _meta: {
             ...generateResponseMetadata(db),
             query_strategy: 'like_fallback',
           },
@@ -160,7 +175,7 @@ export async function searchLegislation(
     }
   }
 
-  return { results: [], _metadata: generateResponseMetadata(db) };
+  return { results: [], _meta: generateResponseMetadata(db) };
 }
 
 /**
@@ -169,11 +184,11 @@ export async function searchLegislation(
  * Keeps the first (highest-ranked) occurrence.
  */
 function deduplicateResults(
-  rows: SearchLegislationResult[],
+  rows: Omit<SearchLegislationResult, '_citation'>[],
   limit: number,
-): SearchLegislationResult[] {
+): Omit<SearchLegislationResult, '_citation'>[] {
   const seen = new Set<string>();
-  const deduped: SearchLegislationResult[] = [];
+  const deduped: Omit<SearchLegislationResult, '_citation'>[] = [];
   for (const row of rows) {
     const key = `${row.document_title}::${row.provision_ref}`;
     if (seen.has(key)) continue;

--- a/src/tools/search-preparatory-works.ts
+++ b/src/tools/search-preparatory-works.ts
@@ -1,0 +1,130 @@
+/**
+ * search_preparatory_works — Search Irish legislative preparatory materials.
+ * Requires a professional-tier database with the preparatory_works table.
+ */
+
+import type { Database } from '@ansvar/mcp-sqlite';
+import { generateResponseMetadata, type ToolResponse, type Citation } from '../utils/metadata.js';
+import { upgradeMessage } from '../capabilities.js';
+
+export interface SearchPreparatoryWorksInput {
+  query: string;
+  document_id?: string;
+  type?: string;
+  limit?: number;
+}
+
+export interface PreparatoryWork {
+  id: string | number;
+  document_id: string | null;
+  title: string | null;
+  type: string | null;
+  content: string;
+  _citation: Citation;
+}
+
+export interface SearchPreparatoryWorksResult {
+  query: string;
+  works: PreparatoryWork[];
+  total_results: number;
+}
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 50;
+
+function tableExists(db: Database, name: string): boolean {
+  const row = db.prepare(
+    "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?"
+  ).get(name) as { 1: number } | undefined;
+  return !!row;
+}
+
+export async function searchPreparatoryWorks(
+  db: Database,
+  input: SearchPreparatoryWorksInput
+): Promise<ToolResponse<SearchPreparatoryWorksResult>> {
+  if (!tableExists(db, 'preparatory_works')) {
+    return {
+      results: { query: input.query ?? '', works: [], total_results: 0 },
+      _meta: {
+        ...generateResponseMetadata(db),
+        note: upgradeMessage('search_preparatory_works'),
+      },
+    };
+  }
+
+  if (!input.query?.trim()) {
+    return {
+      results: { query: '', works: [], total_results: 0 },
+      _meta: generateResponseMetadata(db),
+    };
+  }
+
+  const limit = Math.min(Math.max(input.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
+  const hasFts = tableExists(db, 'preparatory_works_fts');
+
+  interface RawRow {
+    id: string | number;
+    document_id: string | null;
+    title: string | null;
+    type: string | null;
+    content: string;
+  }
+
+  let rows: RawRow[] = [];
+
+  if (hasFts) {
+    let sql = `
+      SELECT pw.id, pw.document_id, pw.title, pw.type, pw.content
+      FROM preparatory_works_fts
+      JOIN preparatory_works pw ON pw.id = preparatory_works_fts.rowid
+      WHERE preparatory_works_fts MATCH ?
+    `;
+    const params: (string | number)[] = [input.query.trim()];
+    if (input.document_id) { sql += ' AND pw.document_id = ?'; params.push(input.document_id); }
+    if (input.type) { sql += ' AND pw.type = ?'; params.push(input.type); }
+    sql += ' ORDER BY bm25(preparatory_works_fts) LIMIT ?';
+    params.push(limit);
+    try {
+      rows = db.prepare(sql).all(...params) as RawRow[];
+    } catch {
+      rows = [];
+    }
+  }
+
+  if (rows.length === 0) {
+    const likePattern = `%${input.query.trim()}%`;
+    let sql = `
+      SELECT id, document_id, title, type, content
+      FROM preparatory_works
+      WHERE (title LIKE ? OR content LIKE ?)
+    `;
+    const params: (string | number)[] = [likePattern, likePattern];
+    if (input.document_id) { sql += ' AND document_id = ?'; params.push(input.document_id); }
+    if (input.type) { sql += ' AND type = ?'; params.push(input.type); }
+    sql += ' LIMIT ?';
+    params.push(limit);
+    rows = db.prepare(sql).all(...params) as RawRow[];
+  }
+
+  const works: PreparatoryWork[] = rows.map(row => ({
+    id: row.id,
+    document_id: row.document_id,
+    title: row.title,
+    type: row.type,
+    content: row.content,
+    _citation: {
+      canonical_ref: `preparatory_works/${row.id}`,
+      display_text: row.title ?? `Preparatory work ${row.id}`,
+      lookup: {
+        tool: 'search_preparatory_works',
+        params: { query: String(row.id) },
+      },
+    },
+  }));
+
+  return {
+    results: { query: input.query, works, total_results: works.length },
+    _meta: generateResponseMetadata(db),
+  };
+}

--- a/src/tools/validate-citation.ts
+++ b/src/tools/validate-citation.ts
@@ -37,7 +37,7 @@ export async function validateCitationTool(
         provision_exists: false,
         warnings: ['Empty citation'],
       },
-      _metadata: generateResponseMetadata(db)
+      _meta: generateResponseMetadata(db)
     };
   }
 
@@ -55,6 +55,6 @@ export async function validateCitationTool(
       status: result.status,
       warnings: result.warnings,
     },
-    _metadata: generateResponseMetadata(db)
+    _meta: generateResponseMetadata(db)
   };
 }

--- a/src/tools/validate-eu-compliance.ts
+++ b/src/tools/validate-eu-compliance.ts
@@ -39,7 +39,7 @@ export async function validateEUCompliance(
         eu_references_found: 0,
         warnings: [`Document "${input.document_id}" not found in database`],
       },
-      _metadata: generateResponseMetadata(db),
+      _meta: generateResponseMetadata(db),
     };
   }
 
@@ -85,6 +85,6 @@ export async function validateEUCompliance(
       warnings,
       recommendations: recommendations.length > 0 ? recommendations : undefined,
     },
-    _metadata: generateResponseMetadata(db),
+    _meta: generateResponseMetadata(db),
   };
 }

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -4,8 +4,17 @@
 
 import type Database from '@ansvar/mcp-sqlite';
 
+export interface Citation {
+  canonical_ref: string;
+  display_text: string;
+  lookup: {
+    tool: string;
+    params: Record<string, string>;
+  };
+}
+
 export interface ResponseMetadata {
-  data_freshness: string;
+  data_age: string;
   disclaimer: string;
   source_authority: string;
   note?: string;
@@ -14,25 +23,21 @@ export interface ResponseMetadata {
 
 export interface ToolResponse<T> {
   results: T;
-  _metadata: ResponseMetadata;
+  _meta: ResponseMetadata;
+  _citation?: Citation;
 }
-
-const STALENESS_THRESHOLD_DAYS = 30;
 
 export function generateResponseMetadata(
   db?: InstanceType<typeof Database>
 ): ResponseMetadata {
-  let freshness = 'Database freshness unknown';
+  let data_age = 'unknown';
 
   if (db) {
     try {
       const row = db.prepare("SELECT value FROM db_metadata WHERE key = 'built_at'").get() as { value: string } | undefined;
       if (row?.value) {
         const builtDate = new Date(row.value);
-        const daysSince = Math.floor((Date.now() - builtDate.getTime()) / (1000 * 60 * 60 * 24));
-        freshness = daysSince > STALENESS_THRESHOLD_DAYS
-          ? `WARNING: Database is ${daysSince} days old. Data may be outdated.`
-          : `Database built ${daysSince} day(s) ago.`;
+        data_age = builtDate.toISOString().slice(0, 10);
       }
     } catch {
       // Ignore metadata read errors
@@ -40,7 +45,7 @@ export function generateResponseMetadata(
   }
 
   return {
-    data_freshness: freshness,
+    data_age,
     disclaimer:
       'This data is derived from eISB open data. ' +
       'Verify against official publications when legal certainty is required.',

--- a/tests/tools/registry.test.ts
+++ b/tests/tools/registry.test.ts
@@ -14,13 +14,13 @@ describe('tool registry', () => {
     expect(names).not.toContain('about');
   });
 
-  it('exposes 12 standard tools (excluding about)', () => {
-    expect(TOOLS).toHaveLength(12);
+  it('exposes 13 standard tools (excluding about)', () => {
+    expect(TOOLS).toHaveLength(13);
   });
 
-  it('exposes 13 tools total when about is included', () => {
+  it('exposes 14 tools total when about is included', () => {
     const tools = buildTools({ version: '1.0.0', fingerprint: 'abc', dbBuilt: 'now' });
-    expect(tools).toHaveLength(13);
+    expect(tools).toHaveLength(14);
   });
 
   it('includes all required standard law MCP tools', () => {


### PR DESCRIPTION
## Summary

Resolves 5 of 6 compliance gaps identified by Fleet CI audit on 2026-04-10.

- **`_metadata` → `_meta` rename**: Updated `ToolResponse<T>` interface and all 12 tool return statements
- **`data_freshness` → `data_age` (ISO 8601)**: Now returns `YYYY-MM-DD` from `built_at` instead of a human string
- **`_citation` added to all retrieval tools**: `canonical_ref`, `display_text`, and `lookup` fields on every returned item/top-level response for `get_provision`, `search_legislation`, `build_legal_stance`, `get_eu_basis`, `get_irish_implementations`, `search_eu_implementations`, `get_provision_eu_basis`
- **`_error_type` + `_meta` on error responses**: `registry.ts` catch block now returns structured JSON with `_error_type: 'tool_execution_error'` and `_meta`
- **`search_preparatory_works` implemented**: Full tool with FTS + LIKE fallback, graceful upgrade notice for free-tier DBs missing the `preparatory_works` table, registered in `registry.ts`
- **`.github/workflows/monthly-rebuild.yml` created**: Monthly cron (`0 2 1 * *`), runs `npm run ingest` + `npm run build`, commits updated DB, triggers `vercel-deploy.yml`

## Test plan

- [x] `npm run typecheck` — passes clean
- [x] `npm run build` — passes clean
- [x] `npm test` — 21/21 passing (updated tool count assertions from 12→13 and 13→14)

## Still needs manual attention

- **npm audit**: 34 vulnerabilities on default branch (not introduced by this PR). Run `npm audit fix` before next deploy.
- **Workflow run status**: Verify `check-updates.yml` and `drift-detect.yml` are passing via GitHub Actions UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)