### PR TITLE
fix(metadata): restore generateResponseMetadata + ToolResponse exports

### DIFF
--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -1,0 +1,51 @@
+/**
+ * Response metadata for Irish Law MCP tool responses.
+ */
+
+import type Database from '@ansvar/mcp-sqlite';
+import type { CitationMetadata } from './citation.js';
+
+export interface ResponseMetadata {
+  data_freshness: string;
+  disclaimer: string;
+  source_authority: string;
+  note?: string;
+  query_strategy?: string;
+}
+
+export interface ToolResponse<T> {
+  results: T;
+  _metadata: ResponseMetadata;
+  _citation?: CitationMetadata;
+}
+
+const STALENESS_THRESHOLD_DAYS = 30;
+
+export function generateResponseMetadata(
+  db?: InstanceType<typeof Database>
+): ResponseMetadata {
+  let freshness = 'Database freshness unknown';
+
+  if (db) {
+    try {
+      const row = db.prepare("SELECT value FROM db_metadata WHERE key = 'built_at'").get() as { value: string } | undefined;
+      if (row?.value) {
+        const builtDate = new Date(row.value);
+        const daysSince = Math.floor((Date.now() - builtDate.getTime()) / (1000 * 60 * 60 * 24));
+        freshness = daysSince > STALENESS_THRESHOLD_DAYS
+          ? `WARNING: Database is ${daysSince} days old. Data may be outdated.`
+          : `Database built ${daysSince} day(s) ago.`;
+      }
+    } catch {
+      // Ignore metadata read errors
+    }
+  }
+
+  return {
+    data_freshness: freshness,
+    disclaimer:
+      'This data is derived from eISB open data. ' +
+      'Verify against official publications when legal certainty is required.',
+    source_authority: 'The National Archives (eISB)',
+  };
+}


### PR DESCRIPTION
## Summary

Commit [1e012de](../commit/1e012de) (#100, "feat: add _citation metadata for deterministic citation pipeline") intended to add a \`_citation\` field to the \`ToolResponse\` interface in \`src/utils/metadata.ts\`. Instead, the diff went from 49 lines to **0**:

\`\`\`
 src/utils/metadata.ts | 49 ---------------
 1 file changed, 0 insertions(+), 49 deletions(-)
\`\`\`

The entire utility module was deleted. 12 importers across \`src/tools/*.ts\` have been failing typecheck since with:

\`\`\`
error TS2306: File '.../src/utils/metadata.ts' is not a module.
\`\`\`

## Fix

Restore the file to its pre-#100 content **and** add the \`_citation?: CitationMetadata\` field that #100 was meant to introduce. The field is referenced in \`get-provision.ts:101\` via \`buildProvisionCitation\` (which lives in the new \`citation.ts\` from #100).

Diff: 1 file, +51 lines.

## Why now

- Unblocks #122 (golden-standard cleanup PR — removes obsolete \`vercel-deploy.yml\` + \`security.yml\`).
- Main has been failing CI typecheck for ~32 days (since #100 merged on 2026-04-07). Any PR touching code paths is currently red on the same TS2306.

## Verification

- \`npm run typecheck\` clean locally
- All 12 import statements unchanged — they were already correct, just had no module
- No call-site changes needed

## Test plan

- [ ] CI typecheck passes on this PR
- [ ] After merge: rebase #122 → CI green → cleanup PR merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)