### PR TITLE
chore(license): declare Irish-PSI-Licence (tri-source — Ireland is NOT statutory-PD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,9 +360,38 @@ Apache License 2.0. See [LICENSE](./LICENSE) for details.
 
 ### Data Licenses
 
-- **Statutes & Legislation:** Office of the Attorney General Ireland (public domain)
-- **Preparatory Works:** Houses of the Oireachtas (public domain)
-- **EU Metadata:** EUR-Lex (EU public domain)
+Ansvar attribution code: **`Irish-PSI-Licence`**. Ireland is NOT a
+statutory-public-domain jurisdiction. The reuse basis is tri-source.
+
+- **Statutes & Bills (Oireachtas copyright):** reproduced under the
+  Houses-of-the-Oireachtas reproduction permission published in the
+  irishstatutebook.ie footer notice: *"Oireachtas Copyright Material is
+  reproduced with the permission of the Houses of the Oireachtas."*
+  Government Copyright (CRRA 2000 s. 191) and Oireachtas Copyright
+  (s. 192) both subsist with 50-year terms.
+- **Administrative materials:** Irish PSI Re-use Regulations 2005
+  (S.I. No. 525 of 2005), implementing the EU PSI Directive. The default
+  PSI licence at [psi.gov.ie](https://psi.gov.ie/) is comparable to
+  OGL-3.0 — non-exclusive, royalty-free, commercial reuse permitted with
+  attribution.
+- **Case law (courts.ie):** separate basis under courts.ie portal terms.
+  Not currently in scope for this MCP. CRRA 2000 s. 71 is a narrow
+  permitted-acts exception (proceedings purpose only) — NOT a PD
+  exclusion.
+- **EU Metadata:** EUR-Lex (EU public-domain notice).
+
+### Coverage scope (tri-source)
+
+| Material type | Basis | In this MCP? |
+|---|---|---|
+| Statutes (Acts) | Oireachtas reproduction permission | YES |
+| Statutory instruments | Government copyright + PSI Re-use Regulations 2005 | YES |
+| Case law (HC, CA, SC) | courts.ie portal terms | NO (separate basis required) |
+| Preparatory works (Bills) | Oireachtas reproduction permission | YES |
+
+See `docs/audits/2026-05-17-eu-copyright-statutory-works-batch-1b-DE-IE-IT-NL-ES.md`
+§2 in the Ansvar architecture-documentation repo for the verbatim CRRA 2000
+ss. 191–192 + s. 71 text and the coverage analysis.
 
 ---
 

--- a/sources.yml
+++ b/sources.yml
@@ -12,9 +12,15 @@ sources:
     update_frequency: 'monthly'
     last_ingested: '2026-02-16'
     license_or_terms:
-      type: 'Government open data'
-      url: 'https://www.irishstatutebook.ie/eli/'
-      summary: 'Irish government open data with ELI URIs'
+      type: 'Irish-PSI-Licence'
+      ansvar_code: 'Irish-PSI-Licence'
+      url: 'https://psi.gov.ie/'
+      url_pattern: '^https?://(?:www\.)?irishstatutebook\.ie/.+'
+      tri_source:
+        statutes: 'Oireachtas reproduction permission — Bills and Acts on irishstatutebook.ie (footer notice: "Oireachtas Copyright Material is reproduced with the permission of the Houses of the Oireachtas")'
+        case_law: 'courts.ie portal terms (separate basis — currently outside this MCP scope)'
+        admin: 'Irish PSI Re-use Regulations 2005 (S.I. No. 525 of 2005), default PSI licence comparable to OGL-3.0'
+      summary: "Ireland is NOT a statutory-PD jurisdiction. Tri-source basis: (1) Oireachtas permission for Bills/Acts on irishstatutebook.ie, (2) courts.ie terms for case-law, (3) Irish PSI Re-use Regulations 2005 for admin materials. This MCP currently ships the statute tier under the Oireachtas reproduction permission. CRRA 2000 ss.191-192 establish Government and Oireachtas copyright with 50-year terms; s.71 is a narrow permitted-acts exception (proceedings purpose only) — NOT a PD exclusion. See infrastructure/attribution-licenses.json Irish-PSI-Licence."
     coverage:
       scope: 'Irish Acts (3,972 statutes, 91K provisions) from 1922 to present'
       limitations: 'Free tier includes all statutes. No case law or preparatory works.'


### PR DESCRIPTION
## Summary

- Sync to verified Ansvar attribution catalog (`Irish-PSI-Licence`).
- Ireland is **NOT** a statutory-PD jurisdiction — CRRA 2000 establishes Crown-copyright-analogue regime with 50-year Government and Oireachtas copyright terms.
- README replaces incorrect "public domain" framing with tri-source basis (Oireachtas permission + PSI Regulations 2005 + courts.ie terms).

## Coverage scope (tri-source)

| Material | Basis | In this MCP? |
|---|---|---|
| Statutes (Acts) | Oireachtas reproduction permission | YES |
| Statutory instruments | Government copyright + PSI Regulations 2005 | YES |
| Case law (HC/CA/SC) | courts.ie portal terms | NO (separate basis) |
| Bills | Oireachtas reproduction permission | YES |

## References

- arch-docs audit: `docs/audits/2026-05-17-eu-copyright-statutory-works-batch-1b-DE-IE-IT-NL-ES.md` §2
- arch-docs manifest: `backstage/catalog/fleet-manifests/irish-law.json` declares `license: Irish-PSI-Licence` with the same tri-source notes.

## Test plan

- [ ] CI passes (license/docs only)
- [ ] README tri-source warning is visible